### PR TITLE
Session setting scripts now aware of current session

### DIFF
--- a/usr/bin/setvncsession
+++ b/usr/bin/setvncsession
@@ -6,6 +6,7 @@
 DESTDIR="${HOME}/.vnc"
 SRCDIR="/usr/share/tribblix-session"
 SUFFIX="xstartup"
+export DESTDIR SUFFIX
 
 usage() {
   echo "$0 - set up vnc session"

--- a/usr/bin/setxsession
+++ b/usr/bin/setxsession
@@ -6,6 +6,7 @@
 DESTDIR="${HOME}"
 SRCDIR="/usr/share/tribblix-session"
 SUFFIX="xinitrc"
+export DESTDIR SUFFIX
 
 usage() {
   echo "$0 - set up X session"

--- a/usr/share/tribblix-session/afterstep.verify
+++ b/usr/share/tribblix-session/afterstep.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/afterstep
+EBIN=${TBIN}
 PKG="retro-desktop"
 DESC="Afterstep"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/amiwm.verify
+++ b/usr/share/tribblix-session/amiwm.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/amiwm
+EBIN=${TBIN}
 PKG="retro-desktop-extras"
 DESC="Amiga-like Window Manager"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/awesome.verify
+++ b/usr/share/tribblix-session/awesome.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/awesome
+EBIN=${TBIN}
 PKG="awesome"
 DESC="awesome window manager"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/awm.verify
+++ b/usr/share/tribblix-session/awm.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/awm
+EBIN=${TBIN}
 PKG="retro-desktop-extras"
 DESC="Ardent Window Manager"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/cde.verify
+++ b/usr/share/tribblix-session/cde.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/dt/bin/dtwm
+EBIN=/usr/dt/bin/dtsession
 PKG="cde"
 DESC="CDE"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/ctwm.verify
+++ b/usr/share/tribblix-session/ctwm.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/ctwm
+EBIN=${TBIN}
 PKG="retro-desktop-extras"
 DESC="CTWM"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/e19.verify
+++ b/usr/share/tribblix-session/e19.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/enlightenment
+EBIN=${TBIN}
 PKG="e19"
 DESC="Enlightenment"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/ede.verify
+++ b/usr/share/tribblix-session/ede.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/startede
+EBIN=${TBIN}
 PKG="ede"
 DESC="EDE"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/fluxbox.verify
+++ b/usr/share/tribblix-session/fluxbox.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/startfluxbox
+EBIN=${TBIN}
 PKG="retro-desktop-extras"
 DESC="Fluxbox"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/fvwm.verify
+++ b/usr/share/tribblix-session/fvwm.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/fvwm
+EBIN=${TBIN}
 PKG="retro-desktop-extras"
 DESC="FVWM"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/i3wm.verify
+++ b/usr/share/tribblix-session/i3wm.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/i3
+EBIN=${TBIN}
 PKG="i3"
 DESC="improved tiling wm"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/icewm.verify
+++ b/usr/share/tribblix-session/icewm.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/icewm
+EBIN=${TBIN}
 PKG="retro-desktop-extras"
 DESC="IceWM"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/mate.verify
+++ b/usr/share/tribblix-session/mate.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/mate-session
+EBIN=${TBIN}
 PKG="mate"
 DESC="MATE"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/mwm.verify
+++ b/usr/share/tribblix-session/mwm.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/mwm
+EBIN=${TBIN}
 PKG="motif"
 DESC="Motif Window Manager"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/openbox.verify
+++ b/usr/share/tribblix-session/openbox.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/openbox
+EBIN=${TBIN}
 PKG="retro-desktop-extras"
 DESC="Openbox"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/pekwm.verify
+++ b/usr/share/tribblix-session/pekwm.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/pekwm
+EBIN=${TBIN}
 PKG="retro-desktop-extras"
 DESC="PekWM"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/piewm.verify
+++ b/usr/share/tribblix-session/piewm.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/piewm
+EBIN=${TBIN}
 PKG="retro-desktop-extras"
 DESC="Window Manager with pie menus"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/tvtwm.verify
+++ b/usr/share/tribblix-session/tvtwm.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/tvtwm
+EBIN=${TBIN}
 PKG="retro-desktop-extras"
 DESC="Tom's virtual Tab Window Manager"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/twm.verify
+++ b/usr/share/tribblix-session/twm.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/twm
+EBIN=${TBIN}
 PKG="x11"
 DESC="TWM"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/vtwm.verify
+++ b/usr/share/tribblix-session/vtwm.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/vtwm
+EBIN=${TBIN}
 PKG="retro-desktop-extras"
 DESC="Virtual tab Window Manager"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/wmaker.verify
+++ b/usr/share/tribblix-session/wmaker.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/wmaker
+EBIN=${TBIN}
 PKG="retro-desktop"
 DESC="Window Maker"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac

--- a/usr/share/tribblix-session/xfce.verify
+++ b/usr/share/tribblix-session/xfce.verify
@@ -1,17 +1,28 @@
 #!/bin/sh
 
 TBIN=/usr/bin/startxfce4
+EBIN=${TBIN}
 PKG="xfce"
 DESC="Xfce"
+
+if [ "${SUFFIX}" = "xinitrc" ]; then
+  SFILE=.${SUFFIX}
+else
+  SFILE=${SUFFIX}
+fi
 
 case $1 in
 -query)
   printf "$DESC "
   if [ -x ${TBIN} ]; then
-     printf "(installed)\n"
+     printf "(installed)"
   else
-     printf "(not installed)\n"
+     printf "(not installed)"
   fi
+  if [ -f ${DESTDIR}/${SFILE} ]; then
+	  grep -q ${EBIN} ${DESTDIR}/${SFILE} && printf " [ACTIVE]"
+  fi
+  printf "\n"
   exit 0
   ;;
 esac


### PR DESCRIPTION
Invoking setxsession/setvncsession without options will show the
currently active session, if any.

Fixes tribblix/tribblix-session#1